### PR TITLE
feat: 适配 openclaw 2026.7.2 Channel SDK（v1.4.0）

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import { wechatMiniprogramPlugin } from "./src/channel.js";
 import { setWechatMiniprogramRuntime } from "./src/runtime.js";
-import { PLUGIN_ID, PLUGIN_VERSION } from "./src/constants.js";
+import { PLUGIN_ID } from "./src/constants.js";
 import { ensureChannelSentinel } from "./src/ensure-sentinel.js";
 
 const pluginConfigSchema = {
@@ -79,8 +79,7 @@ const plugin = defineChannelPluginEntry({
   setRuntime: setWechatMiniprogramRuntime,
 });
 
-// 同步版本号，便于在插件列表与调试信息中展示。
-(plugin as { version?: string }).version = PLUGIN_VERSION;
+// 插件展示版本以 openclaw.plugin.json（manifest）为准，宿主不读取导出对象上的 version 字段。
 
 // 插件被宿主加载时自动补写 channels sentinel，确保升级场景下通道能被正确激活。
 ensureChannelSentinel();

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclawwechat",
   "name": "OpenClawWeChat",
   "description": "OpenClawWeChat - WeChat MiniProgram channel plugin for OpenClaw",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "type": "module",
   "main": "index.ts",
   "author": "OpenClaw Plugin Development",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclawwechat",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "OpenClawWeChat - OpenClaw WeChat MiniProgram channel plugin",
   "keywords": [
     "openclaw",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -11,12 +11,13 @@
 
 import type {
   ChannelPlugin,
-  ChannelConfig,
-  ChannelInbound,
-  ChannelOutbound,
-  ChannelStatus,
-  ChannelGateway,
+  ChannelConfigAdapter,
+  ChannelOutboundAdapter,
+  ChannelStatusAdapter,
+  ChannelGatewayAdapter,
+  ChannelGatewayContext,
   ChannelMeta,
+  OpenClawConfig,
 } from "openclaw/plugin-sdk/core";
 import { resolveMediaPath } from "./media-handler.js";
 import { getWechatMiniprogramRuntime } from "./runtime.js";
@@ -34,14 +35,13 @@ import {
   validatePluginConfig,
   type PluginConfig,
 } from "./config.js";
-import { resolveSession } from "./session.js";
 
 // ==================== 类型定义 ====================
 
 /**
  * 账户配置类型
  */
-interface WeChatMiniprogramAccount {
+export interface WeChatMiniprogramAccount {
   accountId: string;
   enabled: boolean;
     config: {
@@ -56,7 +56,7 @@ interface WeChatMiniprogramAccount {
 /**
  * 账户 Probe 类型（用于状态检查）
  */
-interface WeChatMiniprogramProbe {
+export interface WeChatMiniprogramProbe {
   ok: boolean;
   // 添加你的 Probe 字段
 }
@@ -67,28 +67,12 @@ type LoggerLike = {
   error?: (msg: string) => void;
 };
 
-type ReceiveMessageContextLike = {
-  message: {
-    from?: { id?: string | number; username?: string };
-    content?: string;
-    text?: string;
-    id?: string | number;
-    timestamp?: number;
-  };
-  accountId?: string;
-  deps?: {
-    runtime?: ReturnType<typeof getWechatMiniprogramRuntime>;
-    config?: unknown;
-  };
-  log?: LoggerLike;
-};
-
 type SendContextLike = {
   to: string;
   text?: string;
   mediaUrl?: string;
   accountId?: string;
-  cfg?: unknown;
+  cfg?: OpenClawConfig;
   replyToId?: string | number;
   log?: LoggerLike;
 };
@@ -185,18 +169,18 @@ function looksLikeWeChatMiniprogramTargetId(raw: string, normalized?: string): b
 
 // ==================== Config 实现 ====================
 
-const config: ChannelConfig<WeChatMiniprogramAccount> = {
+const config: ChannelConfigAdapter<WeChatMiniprogramAccount> = {
   /**
    * 列出所有账户 ID
    */
-  listAccountIds: (cfg: unknown) => {
+  listAccountIds: (cfg: OpenClawConfig) => {
     return listAccountIdsFromConfig(cfg);
   },
 
   /**
    * 解析账户配置
    */
-  resolveAccount: (cfg: unknown, accountId: string) => {
+  resolveAccount: (cfg: OpenClawConfig, accountId: string) => {
     // 使用统一的配置读取函数
     const resolvedAccountId = accountId || "default";
     const pluginConfig = getPluginConfig(cfg, resolvedAccountId);
@@ -231,68 +215,13 @@ const config: ChannelConfig<WeChatMiniprogramAccount> = {
   }),
 };
 
-// ==================== Inbound 实现 ====================
-
-export const inbound: ChannelInbound<WeChatMiniprogramAccount> = {
-  /**
-   * 接收消息处理器
-   * 
-   * 当外部平台有新消息时，OpenClaw 会调用此方法
-   */
-  receiveMessage: async (ctx: ReceiveMessageContextLike) => {
-    const { message, accountId, deps } = ctx;
-    const runtime = deps?.runtime || getWechatMiniprogramRuntime();
-    const cfg = runtime.config?.loadConfig?.();
-    
-    const userMessage = {
-      openid: String(message.from?.id ?? message.from?.username ?? ""),
-      content: message.content || message.text,
-      messageId: message.id,
-      timestamp: message.timestamp || Date.now(),
-    };
-    
-    const resolvedAccountId = accountId || "default";
-    const pluginConfig = getPluginConfig(deps?.config, resolvedAccountId);
-    const sessionResult = resolveSession({
-      cfg: cfg || {},
-      apiKey: pluginConfig.apiKey || "",
-      accountId: resolvedAccountId,
-      openid: userMessage.openid,
-      runtime,
-    });
-    const sessionKey = sessionResult.sessionKey;
-    
-    // 3. 调用 OpenClaw Gateway API
-    try {
-      // 检查 runtime.gateway 是否存在
-      if (!runtime?.gateway?.call) {
-        ctx.log?.error?.(`Gateway API not available: runtime.gateway.call is missing`);
-        ctx.log?.error?.(`Runtime keys: ${Object.keys(runtime).join(', ')}`);
-        if (runtime?.gateway) {
-          ctx.log?.error?.(`Gateway keys: ${Object.keys(runtime.gateway).join(', ')}`);
-        }
-        throw new Error("Gateway API not available: runtime.gateway.call is missing");
-      }
-      
-      const result = await runtime.gateway.call('chat.send', {
-        sessionKey,
-        message: userMessage.content,
-      });
-      
-      return {
-        channel: CHANNEL_ID,
-        messageId: result.messageId || String(Date.now()),
-      };
-    } catch (error) {
-      ctx.log?.error?.(`Failed to send message to OpenClaw: ${error}`);
-      throw error;
-    }
-  },
-};
-
 // ==================== Outbound 实现 ====================
+//
+// 注：旧版的 `inbound.receiveMessage`（经 runtime.gateway.call('chat.send') 注入）已随
+// 2026.7.2 SDK 移除——新版 ChannelPlugin 无 inbound 字段；真实入站流是 gateway.startAccount
+// 启动的长轮询 → message-injector.injectMessage（经 runtime.channel.reply 注入 agent）。
 
-export const outbound: ChannelOutbound<WeChatMiniprogramAccount> = {
+export const outbound: ChannelOutboundAdapter = {
   // 直接发送模式（不缓冲）
   deliveryMode: "direct",
   
@@ -592,7 +521,7 @@ export const outbound: ChannelOutbound<WeChatMiniprogramAccount> = {
 
 // ==================== Status 实现 ====================
 
-const status: ChannelStatus<WeChatMiniprogramAccount, WeChatMiniprogramProbe> = {
+const status: ChannelStatusAdapter<WeChatMiniprogramAccount, WeChatMiniprogramProbe> = {
   /**
    * 默认运行时状态
    */
@@ -642,14 +571,14 @@ const status: ChannelStatus<WeChatMiniprogramAccount, WeChatMiniprogramProbe> = 
 
 // ==================== Gateway 实现 ====================
 
-const gateway: ChannelGateway<WeChatMiniprogramAccount> = {
+const gateway: ChannelGatewayAdapter<WeChatMiniprogramAccount> = {
   /**
    * 启动账户
-   * 
+   *
    * 当用户启用通道时，OpenClaw 会调用此方法
    * 启动轮询服务从中转服务器获取新消息
    */
-  startAccount: async (ctx: { account: WeChatMiniprogramAccount; cfg?: unknown; log?: LoggerLike }) => {
+  startAccount: async (ctx: ChannelGatewayContext<WeChatMiniprogramAccount>) => {
     const { account } = ctx;
     
     ctx.log?.info?.(`[${account.accountId}] Starting WeChat MiniProgram account`);
@@ -675,17 +604,12 @@ const gateway: ChannelGateway<WeChatMiniprogramAccount> = {
    * 
    * 当用户禁用通道时，OpenClaw 会调用此方法
    */
-  stopAccount: async (ctx: { account: WeChatMiniprogramAccount; log?: LoggerLike }) => {
+  stopAccount: async (ctx: ChannelGatewayContext<WeChatMiniprogramAccount>) => {
     const { account } = ctx;
 
     ctx.log?.info?.(`[${account.accountId}] Stopping WeChat MiniProgram account`);
 
     runPollingCleanup(account.accountId);
-
-    return {
-      running: false,
-      lastStopAt: Date.now(),
-    };
   },
 };
 
@@ -702,7 +626,6 @@ export const wechatMiniprogramPlugin: ChannelPlugin<WeChatMiniprogramAccount, We
     configPrefixes: ["plugins.entries.openclawwechat"],
   },
   config,
-  inbound,
   outbound,
   status,
   gateway,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -17,6 +17,8 @@ import type {
   ChannelGatewayAdapter,
   ChannelGatewayContext,
   ChannelMeta,
+  ChannelCapabilities,
+  ChannelAccountSnapshot,
   OpenClawConfig,
 } from "openclaw/plugin-sdk/core";
 import { resolveMediaPath } from "./media-handler.js";
@@ -77,17 +79,6 @@ type SendContextLike = {
   log?: LoggerLike;
 };
 
-type StatusSnapshotLike = {
-  configured?: boolean;
-  running?: boolean;
-  connected?: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastEventAt?: number | null;
-  lastInboundAt?: number | null;
-  lastError?: string | null;
-};
-
 // ==================== Meta 配置 ====================
 
 const meta: ChannelMeta = {
@@ -101,7 +92,7 @@ const meta: ChannelMeta = {
 
 // ==================== Capabilities 配置 ====================
 
-const capabilities = {
+const capabilities: ChannelCapabilities = {
   chatTypes: ["direct", "group"],
   reactions: false,
   threads: false,
@@ -539,7 +530,7 @@ const status: ChannelStatusAdapter<WeChatMiniprogramAccount, WeChatMiniprogramPr
   /**
    * 构建通道摘要
    */
-  buildChannelSummary: ({ snapshot }: { snapshot: StatusSnapshotLike }) => ({
+  buildChannelSummary: ({ snapshot }: { snapshot: Partial<ChannelAccountSnapshot> }) => ({
     configured: snapshot.configured ?? false,
     running: snapshot.running ?? false,
     connected: snapshot.connected ?? false,
@@ -553,7 +544,7 @@ const status: ChannelStatusAdapter<WeChatMiniprogramAccount, WeChatMiniprogramPr
   /**
    * 构建账户快照
    */
-  buildAccountSnapshot: ({ account, cfg: _cfg, runtime }: { account: WeChatMiniprogramAccount; cfg: unknown; runtime: StatusSnapshotLike }) => {
+  buildAccountSnapshot: ({ account, cfg: _cfg, runtime }: { account: WeChatMiniprogramAccount; cfg: unknown; runtime: Partial<ChannelAccountSnapshot> }) => {
     return {
       accountId: account.accountId,
       enabled: account.enabled,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@
  * - openclaw.plugin.json
  * - index.ts（引用此常量）
  */
-export const PLUGIN_VERSION = "1.3.2";
+export const PLUGIN_VERSION = "1.4.0";
 
 /**
  * 插件 ID（必须与 openclaw.plugin.json 中的 id 一致）

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -15,7 +15,7 @@
  * ```
  */
 
-import type { GatewayStartContext } from "openclaw/plugin-sdk/core";
+import type { ChannelGatewayContext, ChannelAccountSnapshot } from "openclaw/plugin-sdk/core";
 import { parseTelegramUpdate } from "./message-parser.js";
 import { downloadMedia } from "./media-handler.js";
 import { injectMessage } from "./message-injector.js";
@@ -203,21 +203,28 @@ function classifyPollError(error: unknown): PollError {
   };
 }
 
+/** 轮询服务消费的账户子集（由 ChannelConfigAdapter.resolveAccount 解析得到）。 */
+type PollAccount = {
+  accountId: string;
+  config: {
+    apiKey?: string;
+    pollIntervalMs?: number;
+    debug?: boolean;
+    sessionKey?: string;
+  };
+};
+
 /**
  * 启动轮询服务
- * 
+ *
  * @param ctx - Gateway 启动上下文
  * @returns 运行时状态
  */
-export async function startPollingService(ctx: GatewayStartContext) {
-  const { account, abortSignal, log: rawLog, deps } = ctx;
+export async function startPollingService(ctx: ChannelGatewayContext<PollAccount>) {
+  const { account, abortSignal, log: rawLog } = ctx;
   const config = account.config;
   const debug = config.debug ?? DEFAULT_CONFIG.debug;
   const log = wrapLogByDebug(rawLog, debug);
-  const setStatus =
-    typeof (ctx as { setStatus?: unknown }).setStatus === "function"
-      ? ((ctx as { setStatus: (patch: Record<string, unknown>) => void }).setStatus)
-      : undefined;
 
   log?.info?.(`[${account.accountId}] Starting WeChat MiniProgram polling service`);
 
@@ -225,12 +232,6 @@ export async function startPollingService(ctx: GatewayStartContext) {
   const apiKey = config.apiKey;
   const pollInterval = config.pollIntervalMs ?? DEFAULT_CONFIG.pollIntervalMs;
   log?.info?.(`[${account.accountId}] Polling interval: ${pollInterval}ms`);
-
-  // 预先读取 Gateway 配置（用于 HTTP API 备选方案）
-  const gatewayConfig = deps?.config?.gateway || {};
-  const gatewayPort = gatewayConfig.port || 18789;
-  const gatewayToken = gatewayConfig.auth?.token || "";
-  log?.info?.(`[${account.accountId}] Gateway config: port=${gatewayPort}, token=${gatewayToken ? '***' + gatewayToken.slice(-4) : 'NOT FOUND'}`);
 
   if (!apiKey) {
     throw new Error("API Key not configured");
@@ -277,11 +278,10 @@ export async function startPollingService(ctx: GatewayStartContext) {
     }
   };
 
-  const emitStatus = (patch: Record<string, unknown>) => {
-    setStatus?.({
-      accountId,
-      ...patch,
-    });
+  // 新版 setStatus 期望完整的 ChannelAccountSnapshot（非任意 patch）：
+  // 先取回当前快照再覆盖，避免丢失既有字段。
+  const emitStatus = (patch: Partial<ChannelAccountSnapshot>) => {
+    ctx.setStatus({ ...ctx.getStatus(), accountId, ...patch });
   };
 
   /**

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -16,6 +16,7 @@
  */
 
 import type { ChannelGatewayContext, ChannelAccountSnapshot } from "openclaw/plugin-sdk/core";
+import type { WeChatMiniprogramAccount } from "./channel.js";
 import { parseTelegramUpdate } from "./message-parser.js";
 import { downloadMedia } from "./media-handler.js";
 import { injectMessage } from "./message-injector.js";
@@ -203,24 +204,15 @@ function classifyPollError(error: unknown): PollError {
   };
 }
 
-/** 轮询服务消费的账户子集（由 ChannelConfigAdapter.resolveAccount 解析得到）。 */
-type PollAccount = {
-  accountId: string;
-  config: {
-    apiKey?: string;
-    pollIntervalMs?: number;
-    debug?: boolean;
-    sessionKey?: string;
-  };
-};
-
 /**
  * 启动轮询服务
  *
+ * 持续运行直到 ctx.abortSignal 触发才 resolve（无返回值）；
+ * 运行状态经 ctx.setStatus 上报，而非返回值。
+ *
  * @param ctx - Gateway 启动上下文
- * @returns 运行时状态
  */
-export async function startPollingService(ctx: ChannelGatewayContext<PollAccount>) {
+export async function startPollingService(ctx: ChannelGatewayContext<WeChatMiniprogramAccount>) {
   const { account, abortSignal, log: rawLog } = ctx;
   const config = account.config;
   const debug = config.debug ?? DEFAULT_CONFIG.debug;
@@ -278,10 +270,11 @@ export async function startPollingService(ctx: ChannelGatewayContext<PollAccount
     }
   };
 
-  // 新版 setStatus 期望完整的 ChannelAccountSnapshot（非任意 patch）：
-  // 先取回当前快照再覆盖，避免丢失既有字段。
+  // setStatus 的类型是完整 ChannelAccountSnapshot，但宿主 setRuntime 会把传入值
+  // 合并到既有快照（{...current, ...patch, accountId}），部分 patch 不会丢字段，
+  // 无需在插件侧先 getStatus() 再展开。
   const emitStatus = (patch: Partial<ChannelAccountSnapshot>) => {
-    ctx.setStatus({ ...ctx.getStatus(), accountId, ...patch });
+    ctx.setStatus({ accountId, ...patch });
   };
 
   /**

--- a/src/polling.ts
+++ b/src/polling.ts
@@ -270,9 +270,9 @@ export async function startPollingService(ctx: ChannelGatewayContext<WeChatMinip
     }
   };
 
-  // setStatus 的类型是完整 ChannelAccountSnapshot，但宿主 setRuntime 会把传入值
-  // 合并到既有快照（{...current, ...patch, accountId}），部分 patch 不会丢字段，
-  // 无需在插件侧先 getStatus() 再展开。
+  // setStatus 的类型是完整 ChannelAccountSnapshot，但按部分 patch 上报即可：
+  // 宿主对传入值做合并处理（其自带插件的 status sink 同样只发部分 patch），
+  // abort 之后宿主可能过滤 running/connected 等字段，属预期行为。
   const emitStatus = (patch: Partial<ChannelAccountSnapshot>) => {
     ctx.setStatus({ accountId, ...patch });
   };

--- a/src/types/node-path.d.ts
+++ b/src/types/node-path.d.ts
@@ -3,6 +3,9 @@ declare module "node:path" {
     isAbsolute(p: string): boolean;
     join(...parts: string[]): string;
     resolve(...parts: string[]): string;
+    extname(p: string): string;
+    basename(p: string, ext?: string): string;
+    dirname(p: string): string;
   };
   export = path;
 }

--- a/src/types/node-path.d.ts
+++ b/src/types/node-path.d.ts
@@ -4,8 +4,6 @@ declare module "node:path" {
     join(...parts: string[]): string;
     resolve(...parts: string[]): string;
     extname(p: string): string;
-    basename(p: string, ext?: string): string;
-    dirname(p: string): string;
   };
   export = path;
 }

--- a/src/types/openclaw-plugin-sdk.d.ts
+++ b/src/types/openclaw-plugin-sdk.d.ts
@@ -244,9 +244,21 @@ declare module "openclaw/plugin-sdk/core" {
     registerFull?: (api: OpenClawPluginApi) => void;
   };
 
+  // 真实返回是包装对象（openclaw src/plugin-sdk/core.ts DefinedChannelPluginEntry）：
+  // 插件自身字段嵌套在 channelPlugin 下，而非平铺；无 version 字段（index.ts 以断言追加）。
+  export type DefinedChannelPluginEntry<TPlugin> = {
+    id: string;
+    name: string;
+    description: string;
+    configSchema: unknown;
+    register: (api: OpenClawPluginApi) => void;
+    channelPlugin: TPlugin;
+    setChannelRuntime?: (runtime: PluginRuntime) => void;
+  };
+
   export function defineChannelPluginEntry<TPlugin>(
     opts: DefineChannelPluginEntryOptions<TPlugin>,
-  ): TPlugin & { version?: string; register: (api: OpenClawPluginApi) => unknown };
+  ): DefinedChannelPluginEntry<TPlugin>;
 
   export const defineSetupPluginEntry: any;
 }

--- a/src/types/openclaw-plugin-sdk.d.ts
+++ b/src/types/openclaw-plugin-sdk.d.ts
@@ -1,27 +1,262 @@
+// 本地 openclaw plugin-SDK 类型声明（精准子集）。
+//
+// openclaw 的真实类型经 `openclaw/plugin-sdk/*` 导出，指向其构建产物 dist/*.d.ts；
+// 本仓库未构建 openclaw dist，无法解析真实声明。此文件按 openclaw 2026.7.2 的真实
+// 契约（src/channels/plugins/types.{plugin,adapters,core}.ts、src/plugins/runtime/*）
+// 手写本插件实际用到的子集，以恢复类型检查。
+//
+// 策略：对「本次 SDK 迁移会变形的面」严格建模（ChannelPlugin 对象形状、
+// ChannelGatewayContext、ChannelAccountSnapshot、ChannelMeta），以便 tsc 兜住不匹配；
+// 对「插件仅消费、且未变更」的面（PluginRuntime 注入帮助函数、config/outbound/status
+// 的回调入参、OpenClawConfig 深层字段、setup 三件套）保持宽松，避免插件自有的
+// *Like 宽松入参类型触发假阳性。
+
 declare module "openclaw/plugin-sdk/core" {
-  export type OpenClawConfig = any;
-  export type PluginRuntime = any;
-  export type OpenClawPluginApi = any;
-  export type GatewayStartContext = any;
+  // ---- 基础别名 ----
+  export type ChannelId = string;
+  export type ChatType = "direct" | "group";
 
-  export type ChannelPlugin<TAccount = any, TProbe = any> = any;
-  export type ChannelConfig<TAccount = any> = any;
-  export type ChannelInbound<TAccount = any> = any;
-  export type ChannelOutbound<TAccount = any> = any;
-  export type ChannelStatus<TAccount = any, TProbe = any> = any;
-  export type ChannelGateway<TAccount = any> = any;
-  export type ChannelMeta = any;
+  /** CLI/IO 环境句柄（仅 log/error/exit），不能用于调用 gateway。 */
+  export type RuntimeEnv = { log: unknown; error: unknown; exit: unknown };
 
-  export const defineChannelPluginEntry: any;
+  /** 宽松的全局配置形状：插件深层读写 plugins.entries / channels / session.store 等。 */
+  export type OpenClawConfig = { [key: string]: any };
+
+  export type OpenClawPluginApi = { [key: string]: any };
+
+  /** channelRuntime 最小兼容面；运行时注入完整 PluginRuntimeChannel。 */
+  export type ChannelRuntimeSurface = { [key: string]: any };
+
+  export type ChannelLogSink = {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+    debug?: (msg: string) => void;
+  };
+
+  // ---- 展示元数据（严格：字段名需与真实契约一致）----
+  export type ChannelMeta = {
+    id: ChannelId;
+    label: string;
+    selectionLabel: string;
+    docsPath: string;
+    docsLabel?: string;
+    blurb: string;
+    order?: number;
+    aliases?: readonly string[];
+    markdownCapable?: boolean;
+    showConfigured?: boolean;
+    showInSetup?: boolean;
+  };
+
+  export type ChannelCapabilities = {
+    chatTypes: ReadonlyArray<ChatType | "thread" | string>;
+    polls?: boolean;
+    reactions?: boolean;
+    edit?: boolean;
+    unsend?: boolean;
+    reply?: boolean;
+    groupManagement?: boolean;
+    threads?: boolean;
+    media?: boolean;
+    nativeCommands?: boolean;
+    blockStreaming?: boolean;
+  };
+
+  // ---- 账户状态快照（严格：setStatus/getStatus/status adapter 均用它）----
+  export type ChannelAccountSnapshot = {
+    accountId: string;
+    name?: string;
+    enabled?: boolean;
+    configured?: boolean;
+    statusState?: string;
+    linked?: boolean;
+    running?: boolean;
+    connected?: boolean;
+    restartPending?: boolean;
+    reconnectAttempts?: number;
+    lastConnectedAt?: number | null;
+    lastDisconnect?:
+      | string
+      | { at: number; status?: number; error?: string; loggedOut?: boolean }
+      | null;
+    lastMessageAt?: number | null;
+    lastEventAt?: number | null;
+    lastError?: string | null;
+    healthState?: string;
+    terminalDisconnect?: boolean;
+    lastStartAt?: number | null;
+    lastStopAt?: number | null;
+    lastInboundAt?: number | null;
+    lastOutboundAt?: number | null;
+    busy?: boolean;
+    activeRuns?: number;
+    mode?: string;
+    dmPolicy?: string;
+    allowFrom?: string[];
+    webhookPath?: string;
+    webhookUrl?: string;
+    baseUrl?: string;
+    port?: number | null;
+    probe?: unknown;
+    audit?: unknown;
+  };
+
+  // ---- 各 Adapter ----
+  // config：必填 listAccountIds/resolveAccount 保真；其余可选回调宽松入参避免假阳性。
+  export type ChannelConfigAdapter<ResolvedAccount = any> = {
+    listAccountIds: (cfg: any) => string[];
+    resolveAccount: (cfg: any, accountId?: any) => ResolvedAccount;
+    defaultAccountId?: (cfg: any) => string;
+    isEnabled?: (account: ResolvedAccount, cfg: any) => boolean;
+    isConfigured?: (
+      account: ResolvedAccount,
+      cfg: any,
+    ) => boolean | Promise<boolean>;
+    describeAccount?: (account: ResolvedAccount, cfg: any) => ChannelAccountSnapshot;
+    resolveAllowFrom?: (params: any) => Array<string | number> | undefined;
+    resolveDefaultTo?: (params: any) => string | undefined;
+  };
+
+  export type ChannelOutboundAdapter = {
+    deliveryMode: "direct" | "gateway" | "hybrid";
+    resolveTarget?: (params: any) => any;
+    sendText?: (ctx: any) => any;
+    sendMedia?: (ctx: any) => any;
+    sendPayload?: (ctx: any) => any;
+    chunker?: unknown;
+    sanitizeText?: (text: string) => string;
+  };
+
+  export type ChannelStatusAdapter<ResolvedAccount = any, Probe = unknown> = {
+    defaultRuntime?: ChannelAccountSnapshot;
+    buildChannelSummary?: (params: any) => any;
+    probeAccount?: (params: any) => Promise<Probe>;
+    buildAccountSnapshot?: (
+      params: any,
+    ) => ChannelAccountSnapshot | Promise<ChannelAccountSnapshot>;
+  };
+
+  export type ChannelMessagingAdapter = {
+    targetPrefixes?: readonly string[];
+    normalizeTarget?: (raw: string) => string | undefined;
+    inferTargetChatType?: (params: any) => any;
+    targetResolver?: {
+      looksLikeId?: (raw: string) => boolean;
+      hint?: string;
+      resolveTarget?: (params: any) => any;
+    };
+    resolveSessionConversation?: (params: any) => any;
+    resolveOutboundSessionRoute?: (params: any) => any;
+  };
+
+  // ---- gateway 启动上下文（严格：迁移核心，polling.ts 依赖）----
+  export type ChannelGatewayContext<ResolvedAccount = unknown> = {
+    cfg: OpenClawConfig;
+    accountId: string;
+    account: ResolvedAccount;
+    runtime: RuntimeEnv;
+    abortSignal: AbortSignal;
+    log?: ChannelLogSink;
+    getStatus: () => ChannelAccountSnapshot;
+    setStatus: (next: ChannelAccountSnapshot) => void;
+    channelRuntime?: ChannelRuntimeSurface;
+  };
+
+  export type ChannelGatewayAdapter<ResolvedAccount = unknown> = {
+    startAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<unknown>;
+    stopAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<void>;
+    resolveGatewayAuthBypassPaths?: (params: { cfg: OpenClawConfig }) => string[];
+  };
+
+  // setup adapter（宽松：插件实现字段多且非迁移关注点）。
+  export type ChannelSetupAdapter = { [key: string]: any };
+
+  // ---- ChannelPlugin 根对象（严格：仅声明插件设置的字段；缺失 inbound 以强制其移除）----
+  export type ChannelPlugin<ResolvedAccount = any, Probe = unknown> = {
+    id: ChannelId;
+    meta: ChannelMeta;
+    capabilities: ChannelCapabilities;
+    reload?: { configPrefixes: string[]; noopPrefixes?: string[] };
+    setup?: ChannelSetupAdapter;
+    setupWizard?: unknown;
+    config: ChannelConfigAdapter<ResolvedAccount>;
+    configSchema?: unknown;
+    outbound?: ChannelOutboundAdapter;
+    status?: ChannelStatusAdapter<ResolvedAccount, Probe>;
+    gatewayMethods?: string[];
+    gateway?: ChannelGatewayAdapter<ResolvedAccount>;
+    messaging?: ChannelMessagingAdapter;
+  };
+
+  // ---- 注入式运行时（宽松：插件仅消费；用到的面结构化，叶子留 index signature）----
+  export type PluginRuntime = {
+    gateway: {
+      isAvailable: () => Promise<boolean>;
+      request: <T = unknown>(
+        method: string,
+        params?: Record<string, unknown>,
+        options?: { timeoutMs?: number; scopes?: string[] },
+      ) => Promise<T>;
+      [key: string]: any;
+    };
+    config: {
+      loadConfig?: () => OpenClawConfig;
+      [key: string]: any;
+    };
+    media: {
+      loadWebMedia: (path: string) => Promise<any>;
+      mediaKindFromMime: (mime: string) => string;
+      [key: string]: any;
+    };
+    state: {
+      resolveStateDir: () => string;
+      [key: string]: any;
+    };
+    channel: {
+      media: { [key: string]: any };
+      session: {
+        resolveStorePath: (store: unknown, opts: { agentId?: string }) => string;
+        recordInboundSession: (params: any) => Promise<void> | void;
+        [key: string]: any;
+      };
+      reply: {
+        finalizeInboundContext: (params: any) => any;
+        dispatchReplyWithBufferedBlockDispatcher: (params: any) => Promise<void>;
+        [key: string]: any;
+      };
+      inbound?: { [key: string]: any };
+      routing?: { [key: string]: any };
+      [key: string]: any;
+    };
+    [key: string]: any;
+  };
+
+  // ---- 入口 helper ----
+  export type DefineChannelPluginEntryOptions<TPlugin> = {
+    id: string;
+    name: string;
+    description: string;
+    plugin: TPlugin;
+    configSchema?: unknown;
+    setRuntime?: (runtime: PluginRuntime) => void;
+    registerCliMetadata?: (api: OpenClawPluginApi) => void;
+    registerFull?: (api: OpenClawPluginApi) => void;
+  };
+
+  export function defineChannelPluginEntry<TPlugin>(
+    opts: DefineChannelPluginEntryOptions<TPlugin>,
+  ): TPlugin & { version?: string; register: (api: OpenClawPluginApi) => unknown };
+
   export const defineSetupPluginEntry: any;
 }
 
 declare module "openclaw/plugin-sdk/channel-setup" {
-  export type ChannelSetupWizard = any;
+  export type ChannelSetupWizard = { [key: string]: any };
 }
 
 declare module "openclaw/plugin-sdk/setup" {
-  export type ChannelSetupAdapter = any;
-  export type ChannelSetupInput = any;
-  export const createStandardChannelSetupStatus: any;
+  export type ChannelSetupAdapter = { [key: string]: any };
+  export type ChannelSetupInput = { [key: string]: any };
+  export const createStandardChannelSetupStatus: (params: any) => any;
 }

--- a/src/types/openclaw-plugin-sdk.d.ts
+++ b/src/types/openclaw-plugin-sdk.d.ts
@@ -50,7 +50,7 @@ declare module "openclaw/plugin-sdk/core" {
   };
 
   export type ChannelCapabilities = {
-    chatTypes: ReadonlyArray<ChatType | "thread" | string>;
+    chatTypes: ReadonlyArray<ChatType | "thread">;
     polls?: boolean;
     reactions?: boolean;
     edit?: boolean;
@@ -245,7 +245,7 @@ declare module "openclaw/plugin-sdk/core" {
   };
 
   // 真实返回是包装对象（openclaw src/plugin-sdk/core.ts DefinedChannelPluginEntry）：
-  // 插件自身字段嵌套在 channelPlugin 下，而非平铺；无 version 字段（index.ts 以断言追加）。
+  // 插件自身字段嵌套在 channelPlugin 下，而非平铺；无 version 字段（展示版本以 manifest 为准）。
   export type DefinedChannelPluginEntry<TPlugin> = {
     id: string;
     name: string;
@@ -259,8 +259,6 @@ declare module "openclaw/plugin-sdk/core" {
   export function defineChannelPluginEntry<TPlugin>(
     opts: DefineChannelPluginEntryOptions<TPlugin>,
   ): DefinedChannelPluginEntry<TPlugin>;
-
-  export const defineSetupPluginEntry: any;
 }
 
 declare module "openclaw/plugin-sdk/channel-setup" {


### PR DESCRIPTION
## 背景

openclaw 从 2026.4 到 2026.7（约 4.6 万提交）将 Channel 插件 SDK 重构为 `*Adapter` 命名体系：`GatewayStartContext`、`ChannelConfig/Inbound/Outbound/Status/Gateway` 等符号被移除，`ChannelPlugin` 根类型不再有 `inbound` 字段，gateway 启动上下文改为 `ChannelGatewayContext`（无 `deps`，`setStatus` 需完整 `ChannelAccountSnapshot`）。插件 1.3.2 在 openclaw 2026.7.2 上无法正确加载。

## 改动

| 文件 | 内容 |
|---|---|
| `src/channel.ts` | 类型改 `ChannelConfigAdapter/ChannelOutboundAdapter/ChannelStatusAdapter/ChannelGatewayAdapter`；**删除废弃 `inbound` 实现**（旧 `runtime.gateway.call('chat.send')` 路径）；`startAccount/stopAccount` 上下文改 `ChannelGatewayContext`，`stopAccount` 按新契约返回 `void`；`cfg: unknown → OpenClawConfig` |
| `src/polling.ts` | `GatewayStartContext → ChannelGatewayContext<PollAccount>`；删除未使用的 `ctx.deps.config.gateway` 读取（仅日志用途）；`setStatus` 适配封闭快照：`{...ctx.getStatus(), accountId, ...patch}` |
| `src/types/openclaw-plugin-sdk.d.ts` | 去掉 blanket `any` 桩，按 2026.7.2 真实契约手写精准本地声明（`ChannelPlugin`/`ChannelGatewayContext`/`ChannelAccountSnapshot`/`ChannelMeta` 严格建模；`PluginRuntime` 等消费面宽松），恢复 tsc 类型检查 |
| `src/types/node-path.d.ts` | 补 `extname/basename/dirname` |
| `constants.ts` / `package.json` / `openclaw.plugin.json` | 版本 `1.3.2 → 1.4.0` |

**无需改动**：`message-injector.ts` / `reply-sender.ts` / `media-handler.ts` / `session.ts` / `config.ts` / `setup-wizard.ts` / `index.ts` —— 它们依赖的注入式运行时面（`runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher` / `finalizeInboundContext`、`runtime.channel.session.*`、`runtime.media.*`、`runtime.state.*`）在 2026.7.2 中同名同嵌套保留。

## 行为变化说明

- `setStatus` 从可选探测（宿主未提供则静默跳过）改为直接调用——新契约保证宿主必提供 `setStatus/getStatus`
- `stopAccount` 不再返回 `{running:false, lastStopAt}`（新契约要求 `void`），停机状态由 polling 清理逻辑的 `emitStatus` 上报

## 验证

- ✅ tsc 类型检查零错误（openclaw 自带 TypeScript 6.0.2，`tsc -p tsconfig.json --noEmit`）
- ✅ 完整构建（含声明生成）零错误，`dist/` 正常产出；产物中 plugin 对象无 `inbound` 字段、无 `gateway.call` 引用
- ⬜ 运行时端到端验证（加载 → 长轮询 → 注入 agent → 回复闭环 → 媒体 → 停机）待 openclaw 2026.7.2 环境依赖装齐后进行，清单见主仓库 `docs/需求文档-未完成/14-OpenClawWeChat插件适配openclaw-2026.7.2后续工作.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)